### PR TITLE
Configurable batchsize

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
@@ -20,7 +20,8 @@ namespace EntityFramework.Utilities
         /// </summary>
         /// <param name="items">The items to insert</param>
         /// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
-        void InsertAll(IEnumerable<T> items, DbConnection connection = null);
+        /// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>        
+        void InsertAll(IEnumerable<T> items, DbConnection connection = null, int? batchSize = null);
         IEFBatchOperationFiltered<TContext, T> Where(Expression<Func<T, bool>> predicate);
     }
 
@@ -66,7 +67,8 @@ namespace EntityFramework.Utilities
         /// </summary>
         /// <param name="items">The items to insert</param>
         /// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
-        public void InsertAll(IEnumerable<T> items, DbConnection connection = null)
+        /// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
+        public void InsertAll(IEnumerable<T> items, DbConnection connection = null, int? batchSize = null)
         {
             var con = context.Connection as EntityConnection;
             if (con == null)
@@ -87,7 +89,7 @@ namespace EntityFramework.Utilities
 
                 var properties = tableMapping.PropertyMappings.Select(p => new ColumnMapping { NameInDatabase = p.ColumnName, NameOnObject = p.PropertyName }).ToList();
 
-                provider.InsertItems(items, tableMapping.Schema, tableMapping.TableName, properties, connectionToUse);
+                provider.InsertItems(items, tableMapping.Schema, tableMapping.TableName, properties, connectionToUse, batchSize);
             }
             else
             {

--- a/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
@@ -14,7 +14,7 @@ namespace EntityFramework.Utilities
 
         string GetDeleteQuery(QueryInformation queryInformation);
         string GetUpdateQuery(QueryInformation predicateQueryInfo, QueryInformation modificationQueryInfo);
-        void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection);
+        void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize);
 
         bool CanHandle(DbConnection storeConnection);
 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/Properties/AssemblyInfo.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.2.0")]
-[assembly: AssemblyFileVersion("0.4.2.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -46,7 +46,7 @@ namespace EntityFramework.Utilities
             return string.Format("UPDATE [{0}].[{1}] SET {2} {3}", predicateQueryInfo.Schema, predicateQueryInfo.Table, updateSql, predicateQueryInfo.WhereSql);
         }
 
-        public void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection)
+        public void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize)
         {
             using (var reader = new EFDataReader<T>(items, properties))
             {
@@ -57,7 +57,7 @@ namespace EntityFramework.Utilities
                 }
                 using (SqlBulkCopy copy = new SqlBulkCopy(con))
                 {
-                    copy.BatchSize = Math.Min(reader.RecordsAffected, 15000); //default batch size
+                    copy.BatchSize = Math.Min(reader.RecordsAffected, batchSize ?? 15000); //default batch size
                     if (!string.IsNullOrWhiteSpace(schema))
                     {
                         copy.DestinationTableName = string.Format("[{0}].[{1}]", schema, tableName);


### PR DESCRIPTION
The size of each batch is now configurable for InsertAll. Earlier it was 15000 as default.

The api looks like this

```
EFBatchOperation.For(db, db.Comments).InsertAll(comments, batchSize: 1000);
```
