### PR TITLE
Release 1.0

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/App.config
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/App.config
@@ -2,8 +2,8 @@
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-  </configSections>
+    
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>

--- a/EntityFramework.Utilities/EntityFramework.Utilities/ColumnMapping.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/ColumnMapping.cs
@@ -6,6 +6,7 @@ namespace EntityFramework.Utilities
     public class ColumnMapping
     {
         public string NameOnObject { get; set; }
+        public string StaticValue { get; set; }
         public string NameInDatabase { get; set; }
     }
 }

--- a/EntityFramework.Utilities/EntityFramework.Utilities/ColumnMapping.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/ColumnMapping.cs
@@ -8,5 +8,9 @@ namespace EntityFramework.Utilities
         public string NameOnObject { get; set; }
         public string StaticValue { get; set; }
         public string NameInDatabase { get; set; }
+
+        public string DataType { get; set; }
+
+        public bool IsPrimaryKey { get; set; }
     }
 }

--- a/EntityFramework.Utilities/EntityFramework.Utilities/Configuration.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/Configuration.cs
@@ -12,6 +12,8 @@ namespace EntityFramework.Utilities
             Providers.Add(new SqlQueryProvider());
 
             Log = m => { };
+
+            DisableDefaultFallback = true;
         
         }
 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/DatabaseExtensionMethods.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/DatabaseExtensionMethods.cs
@@ -19,13 +19,13 @@ namespace EntityFramework.Utilities
                 // if you used master db as Initial Catalog, there is no need to change database
                 sqlconnection.ChangeDatabase("master");
 
-                string rollbackCommand = @"ALTER DATABASE " + name + " SET  SINGLE_USER WITH ROLLBACK IMMEDIATE;";
+                string rollbackCommand = @"ALTER DATABASE [" + name + "] SET  SINGLE_USER WITH ROLLBACK IMMEDIATE;";
 
                 SqlCommand deletecommand = new SqlCommand(rollbackCommand, sqlconnection);
 
                 deletecommand.ExecuteNonQuery();
 
-                string deleteCommand = @"DROP DATABASE " + name + ";";
+                string deleteCommand = @"DROP DATABASE [" + name + "];";
 
                 deletecommand = new SqlCommand(deleteCommand, sqlconnection);
 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFDataReader.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFDataReader.cs
@@ -19,6 +19,11 @@ namespace EntityFramework.Utilities
             Properties = properties.Select(p => p.NameOnObject).ToList();
             Accessors = properties.Select(p =>
             {
+                if (p.StaticValue != null)
+                {
+                    Func<T,object> func = x => p.StaticValue;
+                    return func;
+                }
 
                 var parts = p.NameOnObject.Split('.');
 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFQueryHelpers.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFQueryHelpers.cs
@@ -140,6 +140,12 @@ namespace EntityFramework.Utilities
                 childCollectionModifiers.Add(mce);
                 temp = mce.Arguments[0];
             }
+            //This loop is for VB, See: https://github.com/MikaelEliasson/EntityFramework.Utilities/issues/29
+            while (temp is UnaryExpression)
+            {
+                var ue = temp as UnaryExpression;
+                temp = ue.Operand;
+            }
             childCollectionModifiers.Reverse(); //We parse from right to left so reverse it
             if (!(temp is MemberExpression))
             {

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EntityFramework.Utilities.csproj
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EntityFramework.Utilities.csproj
@@ -32,10 +32,11 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.0.2\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.0.2\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EntityFramework.Utilities.csproj
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EntityFramework.Utilities.csproj
@@ -32,11 +32,11 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/EntityFramework.Utilities/EntityFramework.Utilities/ExpressionHelper.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/ExpressionHelper.cs
@@ -30,6 +30,19 @@ namespace EntityFramework.Utilities
             return final;
         }
 
+        public static string GetPropertyName<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyLambda)
+        {
+            Type type = typeof(TSource);
+
+            var temp = propertyLambda.Body;
+            while (temp is UnaryExpression)
+            {
+                temp = (temp as UnaryExpression).Operand;
+            }
+            MemberExpression member = temp as MemberExpression;
+            return member.Member.Name;
+        }
+
         //http://stackoverflow.com/a/2824409/507279
         internal static Action<T, TP> PropertyExpressionToSetter<T, TP>(Expression<Func<T, TP>> prop)
         {

--- a/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
@@ -11,14 +11,18 @@ namespace EntityFramework.Utilities
         bool CanDelete { get; }
         bool CanUpdate { get; }
         bool CanInsert { get; }
+        bool CanBulkUpdate { get; }
 
         string GetDeleteQuery(QueryInformation queryInformation);
         string GetUpdateQuery(QueryInformation predicateQueryInfo, QueryInformation modificationQueryInfo);
         void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize);
+        void UpdateItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, UpdateSpecification<T> updateSpecification);
 
         bool CanHandle(DbConnection storeConnection);
 
 
         QueryInformation GetQueryInformation<T>(System.Data.Entity.Core.Objects.ObjectQuery<T> query);
+
+
     }
 }

--- a/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Core.Mapping;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Infrastructure;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using System.Reflection;
 
 namespace EntityFramework.Utilities
 {
@@ -54,6 +56,19 @@ namespace EntityFramework.Utilities
         /// </summary>
         public List<PropertyMapping> PropertyMappings { get; set; }
 
+        /// <summary>
+        /// Null if not TPH
+        /// </summary>
+        public TPHConfiguration TPHConfiguration { get; set; }
+
+
+    }
+
+    public class TPHConfiguration
+    {
+        public Dictionary<Type, string> Mappings { get; set; }
+        public string ColumnName { get; set; }
+
     }
 
     /// <summary>
@@ -70,6 +85,11 @@ namespace EntityFramework.Utilities
         /// The column that property is mapped to
         /// </summary>
         public string ColumnName { get; set; }
+
+        /// <summary>
+        /// Used when we have TPH to exclude entities
+        /// </summary>
+        public Type ForEntityType { get; set; }
     }
 
     /// <summary>
@@ -92,6 +112,8 @@ namespace EntityFramework.Utilities
 
             var metadata = ((IObjectContextAdapter)db).ObjectContext.MetadataWorkspace;
 
+            //EF61Test(metadata);
+
             // Conceptual part of the model has info about the shape of our entity classes
             var conceptualContainer = metadata.GetItems<EntityContainer>(DataSpace.CSpace).Single();
 
@@ -101,12 +123,18 @@ namespace EntityFramework.Utilities
             // Object part of the model that contains info about the actual CLR types
             var objectItemCollection = ((ObjectItemCollection)metadata.GetItemCollection(DataSpace.OSpace));
 
-            // Mapping part of model is not public, so we need to write to xml and use 'LINQ to XML'
-            var edmx = GetEdmx(db);
-
             // Loop thru each entity type in the model
             foreach (var set in conceptualContainer.BaseEntitySets.OfType<EntitySet>())
             {
+
+                // Find the mapping between conceptual and storage model for this entity set
+                var mapping = metadata.GetItems<EntityContainerMapping>(DataSpace.CSSpace)
+                        .Single()
+                        .EntitySetMappings
+                        .Single(s => s.EntitySet == set);
+
+
+
                 var typeMapping = new TypeMapping
                 {
                     TableMappings = new List<TableMapping>(),
@@ -115,51 +143,91 @@ namespace EntityFramework.Utilities
 
                 this.TypeMappings.Add(typeMapping.EntityType, typeMapping);
 
-                // Get the mapping fragments for this type
-                // (types may have mutliple fragments if 'Entity Splitting' is used)
-                var mappingFragments = edmx
-                    .Descendants()
-                    .Single(e =>
-                        e.Name.LocalName == "EntityTypeMapping"
-                        && (e.Attribute("TypeName").Value == set.ElementType.FullName || e.Attribute("TypeName").Value == string.Format("IsTypeOf({0})", set.ElementType.FullName)))
-                    .Descendants()
-                    .Where(e => e.Name.LocalName == "MappingFragment");
-
-                foreach (var mapping in mappingFragments)
+                var tableMapping = new TableMapping
                 {
-                    var tableMapping = new TableMapping
+                    PropertyMappings = new List<PropertyMapping>()
+                };
+                var mappingToLookAt = mapping.EntityTypeMappings.FirstOrDefault(m => m.IsHierarchyMapping) ?? mapping.EntityTypeMappings.First();
+                tableMapping.Schema = mappingToLookAt.Fragments[0].StoreEntitySet.Schema;
+                tableMapping.TableName = mappingToLookAt.Fragments[0].StoreEntitySet.Table;
+                typeMapping.TableMappings.Add(tableMapping);
+
+                Action<Type, System.Data.Entity.Core.Mapping.PropertyMapping, string> recurse = null;
+                recurse = (t, item, path) =>
+                {
+                    if (item is ComplexPropertyMapping)
                     {
-                        PropertyMappings = new List<PropertyMapping>()
-                    };
-                    typeMapping.TableMappings.Add(tableMapping);
-
-                    // Find the table that this fragment maps to
-                    var storeset = mapping.Attribute("StoreEntitySet").Value;
-                    var store = storeContainer
-                        .BaseEntitySets.OfType<EntitySet>()
-                        .Single(s => s.Name == storeset);
-
-                    tableMapping.TableName = (string)store.MetadataProperties["Table"].Value;
-                    tableMapping.Schema = (string)store.MetadataProperties["Schema"].Value;
-
-                    // Find the property-to-column mappings
-                    var propertyMappings = mapping
-                        .Descendants()
-                        .Where(e => e.Name.LocalName == "ScalarProperty");
-
-                    foreach (var propertyMapping in propertyMappings)
+                        var complex = item as ComplexPropertyMapping;
+                        foreach (var child in complex.TypeMappings[0].PropertyMappings)
+                        {
+                            recurse(t, child, path + complex.Property.Name + ".");
+                        }
+                    }
+                    else if (item is ScalarPropertyMapping)
                     {
-                        var propertyName = GetFullName(propertyMapping);
-                        var columnName = propertyMapping.Attribute("ColumnName").Value;
-
+                        var scalar = item as ScalarPropertyMapping;
                         tableMapping.PropertyMappings.Add(new PropertyMapping
                         {
-                            PropertyName = propertyName,
-                            ColumnName = columnName
+                            ColumnName = scalar.Column.Name,
+                            PropertyName = path + item.Property.Name,
+                            ForEntityType = t
                         });
                     }
+                };
+
+                Func<MappingFragment, Type> getClr = m => {
+                    return GetClrTypeFromTypeMapping(metadata, objectItemCollection, m.TypeMapping as EntityTypeMapping);
+                };
+
+                if (mapping.EntityTypeMappings.Any(m => m.IsHierarchyMapping))
+                {
+                    var withConditions = mapping.EntityTypeMappings.Where(m => m.Fragments[0].Conditions.Any()).ToList();
+                    tableMapping.TPHConfiguration = new TPHConfiguration
+                       {
+                           ColumnName = withConditions.First().Fragments[0].Conditions[0].Column.Name,
+                           Mappings = new Dictionary<Type,string>()
+                       };
+                    foreach (var item in withConditions)
+                    {
+                        tableMapping.TPHConfiguration.Mappings.Add(
+                            getClr(item.Fragments[0]),
+                            GetNonPublicPropertyValue(item.Fragments[0].Conditions[0], "Value").ToString()
+                            );
+                    }
                 }
+
+                foreach (var entityType in mapping.EntityTypeMappings)
+                {
+                    foreach (var item in entityType.Fragments[0].PropertyMappings)
+                    {
+                        recurse(getClr(entityType.Fragments[0]), item, "");
+                    }
+                }
+
+                //Inheriting propertymappings contains duplicates for id's. 
+                tableMapping.PropertyMappings = tableMapping.PropertyMappings.GroupBy(p => p.PropertyName)
+                    .Select(g => g.OrderByDescending(outer => g.Count(inner => inner.ForEntityType.IsSubclassOf(outer.ForEntityType))).First())
+                    .ToList();
             }
+        }
+
+        private Type GetClrTypeFromTypeMapping(MetadataWorkspace metadata, ObjectItemCollection objectItemCollection, EntityTypeMapping mapping)
+        {
+            return GetClrType(metadata, objectItemCollection, mapping.EntityType ?? mapping.IsOfEntityTypes.First());
+        }
+
+
+        static object GetNonPublicPropertyValue(object o, string propertyName)
+        {
+            return o.GetType()
+              .GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance)
+              .GetValue(o, null);
+        }
+
+        private static dynamic GetProperty(string property, object instance)
+        {
+            var type = instance.GetType();
+            return type.InvokeMember(property, BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, instance, null);
         }
 
         private string GetFullName(XElement propertyMapping)
@@ -173,10 +241,15 @@ namespace EntityFramework.Utilities
 
         private static Type GetClrType(MetadataWorkspace metadata, ObjectItemCollection objectItemCollection, EntitySet set)
         {
+            return GetClrType(metadata, objectItemCollection, set.ElementType);
+        }
+
+        private static Type GetClrType(MetadataWorkspace metadata, ObjectItemCollection objectItemCollection, EntityTypeBase type)
+        {
             return metadata
                    .GetItems<EntityType>(DataSpace.OSpace)
                    .Select(objectItemCollection.GetClrType)
-                   .Single(e => e.Name == set.ElementType.Name);
+                   .Single(e => e.Name == type.Name);
         }
 
         private static XDocument GetEdmx(DbContext db)

--- a/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
@@ -149,7 +149,7 @@ namespace EntityFramework.Utilities
                 };
                 var mappingToLookAt = mapping.EntityTypeMappings.FirstOrDefault(m => m.IsHierarchyMapping) ?? mapping.EntityTypeMappings.First();
                 tableMapping.Schema = mappingToLookAt.Fragments[0].StoreEntitySet.Schema;
-                tableMapping.TableName = mappingToLookAt.Fragments[0].StoreEntitySet.Table;
+                tableMapping.TableName = mappingToLookAt.Fragments[0].StoreEntitySet.Table ?? mappingToLookAt.Fragments[0].StoreEntitySet.Name;
                 typeMapping.TableMappings.Add(tableMapping);
 
                 Action<Type, System.Data.Entity.Core.Mapping.PropertyMapping, string> recurse = null;

--- a/EntityFramework.Utilities/EntityFramework.Utilities/Properties/AssemblyInfo.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.0.0")]
-[assembly: AssemblyFileVersion("0.5.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EntityFramework.Utilities/EntityFramework.Utilities/packages.config
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net40" />
 </packages>

--- a/EntityFramework.Utilities/EntityFramework.Utilities/packages.config
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.2" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
 </packages>

--- a/EntityFramework.Utilities/PerformanceTests/App.config
+++ b/EntityFramework.Utilities/PerformanceTests/App.config
@@ -2,8 +2,8 @@
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-  </configSections>
+    
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>

--- a/EntityFramework.Utilities/PerformanceTests/PerformanceTests.csproj
+++ b/EntityFramework.Utilities/PerformanceTests/PerformanceTests.csproj
@@ -34,10 +34,11 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.0.2\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.0.2\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text">
       <HintPath>..\packages\ServiceStack.Text.3.8.3\lib\net35\ServiceStack.Text.dll</HintPath>

--- a/EntityFramework.Utilities/PerformanceTests/packages.config
+++ b/EntityFramework.Utilities/PerformanceTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.2" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.8.3" />
 </packages>

--- a/EntityFramework.Utilities/Tests/App.config
+++ b/EntityFramework.Utilities/Tests/App.config
@@ -4,6 +4,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlCeConnectionFactory, EntityFramework">
@@ -12,8 +13,8 @@
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
       <provider invariantName="System.Data.SqlServerCe.4.0" type="System.Data.Entity.SqlServerCompact.SqlCeProviderServices, EntityFramework.SqlServerCompact" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <runtime>

--- a/EntityFramework.Utilities/Tests/DeleteByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/DeleteByQueryTest.cs
@@ -156,7 +156,7 @@ namespace Tests
         public void DeleteAll_NoProvider_UsesDefaultDelete()
         {
             string fallbackText = null;
-
+            Configuration.DisableDefaultFallback = false;
             Configuration.Log = str => fallbackText = str;
 
             using (var db = Context.SqlCe())

--- a/EntityFramework.Utilities/Tests/DeleteByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/DeleteByQueryTest.cs
@@ -9,7 +9,7 @@ using Tests.FakeDomain.Models;
 namespace Tests
 {
     [TestClass]
-    public class DeleteAllTest
+    public class DeleteByQueryTest
     {
         [TestMethod]
         public void DeleteAll_PropertyEquals_DeletesAllMatchesAndNothingElse()

--- a/EntityFramework.Utilities/Tests/FakeDomain/Contact.cs
+++ b/EntityFramework.Utilities/Tests/FakeDomain/Contact.cs
@@ -10,5 +10,17 @@ namespace Tests.FakeDomain
         public string Title { get; set; }
         public ICollection<PhoneNumber> PhoneNumbers { get; set; }
         public ICollection<Email> Emails { get; set; }
+
+        public static Contact Build(string firstname, string lastname, string title, DateTime? birthdate = null)
+        {
+            return new Contact
+            {
+                Id = Guid.NewGuid(),
+                FirstName = firstname,
+                LastName = lastname,
+                Title = title,
+                BirthDate = birthdate ?? DateTime.Today
+            };
+        }
     }
 }

--- a/EntityFramework.Utilities/Tests/FakeDomain/Context.cs
+++ b/EntityFramework.Utilities/Tests/FakeDomain/Context.cs
@@ -30,8 +30,9 @@ namespace Tests.FakeDomain
             modelBuilder.ComplexType<Address>();
 
             //Table per Type Hierarchy setup
-            modelBuilder.Entity<Person>().ToTable("Person");
-            modelBuilder.Entity<Contact>().ToTable("Contact");
+            modelBuilder.Entity<Person>()
+                .Map<Person>(m => m.Requires("Type").HasValue("Person"))
+                .Map<Contact>(m => m.Requires("Type").HasValue("Contact"));
         }
 
         public static Context Sql()

--- a/EntityFramework.Utilities/Tests/FakeDomain/Person.cs
+++ b/EntityFramework.Utilities/Tests/FakeDomain/Person.cs
@@ -11,5 +11,16 @@ namespace Tests.FakeDomain
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public DateTime BirthDate { get; set; }
+
+        public static Person Build(string firstname, string lastname, DateTime? birthdate = null)
+        {
+            return new Person
+            {
+                Id = Guid.NewGuid(),
+                FirstName = firstname,
+                LastName = lastname,
+                BirthDate = birthdate ?? DateTime.Today
+            };
+        }
     }
 }

--- a/EntityFramework.Utilities/Tests/InsertTests.cs
+++ b/EntityFramework.Utilities/Tests/InsertTests.cs
@@ -184,7 +184,7 @@ namespace Tests
         public void InsertAll_NoProvider_UsesDefaultInsert()
         {
             string fallbackText = null;
-
+            Configuration.DisableDefaultFallback = false;
             Configuration.Log = str => fallbackText = str;
 
             using (var db = Context.SqlCe())

--- a/EntityFramework.Utilities/Tests/InsertTests.cs
+++ b/EntityFramework.Utilities/Tests/InsertTests.cs
@@ -23,62 +23,46 @@ namespace Tests
                 db.Database.Create();
 
                 List<Contact> people = new List<Contact>();
-                people.Add(new Contact
-                {
-                    FirstName = "FN1",
-                    LastName = "LN1",
-                    Title = "Director",
-                    Id = Guid.NewGuid(),
-                    BirthDate = DateTime.Today,
-                    PhoneNumbers = new List<PhoneNumber>(){
-                       new PhoneNumber{
-                           Id = Guid.NewGuid(),
-                           Number = "10134"
-                       },
-                       new PhoneNumber{
-                           Id = Guid.NewGuid(),
-                           Number = "15678"
-                       },
-                    }
-                });
-                people.Add(new Contact
-                {
-                    FirstName = "FN2",
-                    LastName = "LN2",
-                    Title = "Associate",
-                    Id = Guid.NewGuid(),
-                    BirthDate = DateTime.Today,
-                    PhoneNumbers = new List<PhoneNumber>(){
-                       new PhoneNumber{
-                           Id = Guid.NewGuid(),
-                           Number = "20134"
-                       },
-                       new PhoneNumber{
-                           Id = Guid.NewGuid(),
-                           Number = "25678"
-                       },
-                    },
-                    Emails = new List<Email>()
-                {
-                    new Email{Id = Guid.NewGuid(), Address = "m21@mail.com" },
-                    new Email{Id = Guid.NewGuid(), Address = "m22@mail.com" },
-                }
-                });
-                people.Add(new Contact
-                {
-                    FirstName = "FN3",
-                    LastName = "LN3",
-                    Title = "Vice President",
-                    Id = Guid.NewGuid(),
-                    BirthDate = DateTime.Today,
-                    Emails = new List<Email>()
-                {
-                    new Email{Id = Guid.NewGuid(), Address = "m31@mail.com" },
-                    new Email{Id = Guid.NewGuid(), Address = "m32@mail.com" },
-                }
-                });
+                people.Add(Contact.Build("FN1", "LN1", "Director"));
+                people.Add(Contact.Build("FN2", "LN2", "Associate"));
+                people.Add(Contact.Build("FN3", "LN3", "Vice President"));
 
                 EFBatchOperation.For(db, db.People).InsertAll(people);
+            }
+
+            using (var db = Context.Sql())
+            {
+                var contacts = db.People.OfType<Contact>().OrderBy(c => c.FirstName).ToList();
+                Assert.AreEqual(3, contacts.Count);
+                Assert.AreEqual("FN1", contacts.First().FirstName);
+                Assert.AreEqual("Director", contacts.First().Title);
+            }
+        }
+
+        [TestMethod]
+        public void InsertAll_InsertItems_WithTypeHierarchyBase()
+        {
+            using (var db = Context.Sql())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+
+                List<Person> people = new List<Person>();
+                people.Add(Person.Build("FN1", "LN1"));
+                people.Add(Person.Build("FN2", "LN2"));
+                people.Add(Person.Build("FN3", "LN3"));
+
+                EFBatchOperation.For(db, db.People).InsertAll(people);
+            }
+
+            using (var db = Context.Sql())
+            {
+                var contacts = db.People.OrderBy(c => c.FirstName).ToList();
+                Assert.AreEqual(3, contacts.Count);
+                Assert.AreEqual("FN1", contacts.First().FirstName);
             }
         }
 
@@ -105,6 +89,7 @@ namespace Tests
             using (var db = Context.Sql())
             {
                 Assert.AreEqual(3, db.BlogPosts.Count());
+                Assert.AreEqual("m@m.com", db.BlogPosts.First().Author.Email);
             }
         }
 

--- a/EntityFramework.Utilities/Tests/Tests.csproj
+++ b/EntityFramework.Utilities/Tests/Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="ConnectionStringReader.cs" />
     <Compile Include="ConnectionStrings.cs" />
     <Compile Include="AttachAndModifyTest.cs" />
+    <Compile Include="UpdateBulkTests.cs" />
     <Compile Include="FakeDomain\Contact.cs" />
     <Compile Include="FakeDomain\Email.cs" />
     <Compile Include="FakeDomain\Person.cs" />
@@ -84,7 +85,7 @@
     <Compile Include="IncludeTest.cs" />
     <Compile Include="Models\Comment.cs" />
     <Compile Include="RenamedColumnsUpdateAllTest.cs" />
-    <Compile Include="DeleteAllTest.cs" />
+    <Compile Include="DeleteByQueryTest.cs" />
     <Compile Include="Models\BlogPost.cs" />
     <Compile Include="FakeDomain\Context.cs" />
     <Compile Include="FakeDomain\RenamedAndReorderedContext.cs" />
@@ -93,7 +94,7 @@
     <Compile Include="Models\ReorderedBlogPost.cs" />
     <Compile Include="InsertTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="UpdateAllTest.cs" />
+    <Compile Include="UpdateByQueryTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/EntityFramework.Utilities/Tests/Tests.csproj
+++ b/EntityFramework.Utilities/Tests/Tests.csproj
@@ -37,10 +37,11 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.0.2\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.0.2\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServerCompact">
       <HintPath>..\packages\EntityFramework.SqlServerCompact.6.0.2\lib\net40\EntityFramework.SqlServerCompact.dll</HintPath>

--- a/EntityFramework.Utilities/Tests/UpdateAllTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateAllTest.cs
@@ -70,6 +70,41 @@ namespace Tests
               Assert.AreEqual(20, post.Reads);
           }
       }
+      private int Get20()
+      {
+          return 20;
+      }
+      [TestMethod]
+      public void UpdateAll_SetFromMethod()
+      {
+          SetupBasePosts();
+
+          int count;
+          using (var db = Context.Sql())
+          {
+              count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").Update(b => b.Reads, b => Get20());
+              Assert.AreEqual(1, count);
+          }
+
+          using (var db = Context.Sql())
+          {
+              var post = db.BlogPosts.First(p => p.Title == "T2");
+              Assert.AreEqual(20, post.Reads);
+          }
+      }
+
+      [TestMethod]
+      public void UpdateAll_SetFromProperty()
+      {
+          SetupBasePosts();
+
+          int count;
+          using (var db = Context.Sql())
+          {
+              count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Created == DateTime.Now.AddDays(2)).Update(b => b.Created, b => DateTime.Now);
+              Assert.AreEqual(1, count);
+          }
+      }
 
       [TestMethod]
       public void UpdateAll_ConcatStringValue()

--- a/EntityFramework.Utilities/Tests/UpdateBulkTests.cs
+++ b/EntityFramework.Utilities/Tests/UpdateBulkTests.cs
@@ -8,7 +8,7 @@ using Tests.FakeDomain.Models;
 namespace Tests
 {
     [TestClass]
-    public class UpdateBulkTests 
+    public class UpdateBulkTests
     {
         [TestMethod]
         public void UpdateBulk_UpdatesAll()
@@ -18,13 +18,19 @@ namespace Tests
             using (var db = Context.Sql())
             {
                 var posts = db.BlogPosts.ToList();
-
-                Assert.AreEqual(3, db.BlogPosts.Count());
+                foreach (var post in posts)
+	            {
+                    post.Title = post.Title.Replace("1", "4").Replace("2", "8").Replace("3", "12");
+	            }
+                EFBatchOperation.For(db, db.BlogPosts).UpdateAll(posts, spec => spec.ColumnsToUpdate(p => p.Title));
             }
 
             using (var db = Context.Sql())
             {
-                Assert.AreEqual(3, db.BlogPosts.Count());
+                var posts = db.BlogPosts.OrderBy(b => b.ID).ToList();
+                Assert.AreEqual("T4", posts[0].Title);
+                Assert.AreEqual("T8", posts[1].Title);
+                Assert.AreEqual("T12", posts[2].Title);
             }
         }
 
@@ -34,7 +40,7 @@ namespace Tests
             {
                 if (db.Database.Exists())
                 {
-                    db.Database.Delete();
+                    db.Database.ForceDelete();
                 }
                 db.Database.Create();
 
@@ -45,136 +51,6 @@ namespace Tests
                 };
 
                 EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
-            }
-        }
-
-        [TestMethod]
-        public void InsertAll_WrongColumnOrder_InsertsItems()
-        {
-            using (var db = new ReorderedContext())
-            {
-                if (db.Database.Exists())
-                {
-                    db.Database.Delete();
-                }
-                db.Database.Create();
-            }
-
-            using (var db = Context.Sql())
-            {
-
-                var list = new List<BlogPost>(){
-                    BlogPost.Create("T1"),
-                    BlogPost.Create("T2"),
-                    BlogPost.Create("T3")
-                };
-
-                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
-            }
-
-            using (var db = Context.Sql())
-            {
-                Assert.AreEqual(3, db.BlogPosts.Count());
-            }
-        }
-
-        [TestMethod]
-        public void InsertAll_WrongColumnOrderAndRenamedColumn_InsertsItems()
-        {
-            using (var db = new RenamedAndReorderedContext())
-            {
-                if (db.Database.Exists())
-                {
-                    db.Database.Delete();
-                }
-                db.Database.Create();
-                db.Database.ExecuteSqlCommand("drop table dbo.RenamedAndReorderedBlogPosts;");
-                db.Database.ExecuteSqlCommand(RenamedAndReorderedBlogPost.CreateTableSql());
-            }
-
-            using (var db = new RenamedAndReorderedContext())
-            {
-
-                var list = new List<RenamedAndReorderedBlogPost>(){
-                    RenamedAndReorderedBlogPost.Create("T1"),
-                    RenamedAndReorderedBlogPost.Create("T2"),
-                    RenamedAndReorderedBlogPost.Create("T3")
-                };
-
-                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
-            }
-
-            using (var db = new RenamedAndReorderedContext())
-            {
-                Assert.AreEqual(3, db.BlogPosts.Count());
-            }
-        }
-
-        [TestMethod]
-        public void InsertAll_NoProvider_UsesDefaultInsert()
-        {
-            string fallbackText = null;
-
-            Configuration.Log = str => fallbackText = str;
-
-            using (var db = Context.SqlCe())
-            {
-                if (db.Database.Exists())
-                {
-                    db.Database.Delete();
-                }
-                db.Database.Create();
-            }
-
-            var list = new List<BlogPost>(){
-                    BlogPost.Create("T1"),
-                    BlogPost.Create("T2"),
-                    BlogPost.Create("T3")
-                };
-
-            using (var db = Context.SqlCe())
-            {
-                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
-            }
-
-            using (var db = Context.SqlCe())
-            {
-                Assert.AreEqual(3, db.BlogPosts.Count());
-            }
-
-            Assert.IsNotNull(fallbackText);
-        }
-
-
-        [TestMethod]
-        public void InsertAll_WithForeignKey()
-        {
-            int postId = -1;
-            using (var db = Context.Sql())
-            {
-                if (db.Database.Exists())
-                {
-                    db.Database.Delete();
-                }
-                db.Database.Create();
-
-                var bp = BlogPost.Create("B1");
-                db.BlogPosts.Add(bp);
-                db.SaveChanges();
-                postId = bp.ID;
-
-                var comments = new List<Comment>(){
-                    new Comment{Text = "C1", PostId = bp.ID },
-                    new Comment{Text = "C2", PostId = bp.ID },
-                };
-
-                EFBatchOperation.For(db, db.Comments).InsertAll(comments);
-            }
-
-            using (var db = Context.Sql())
-            {
-                Assert.AreEqual(2, db.Comments.Count());
-                Assert.AreEqual(2, db.Comments.Count(c => c.PostId == postId));
             }
         }
     }

--- a/EntityFramework.Utilities/Tests/UpdateBulkTests.cs
+++ b/EntityFramework.Utilities/Tests/UpdateBulkTests.cs
@@ -1,0 +1,181 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using EntityFramework.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tests.FakeDomain;
+using Tests.FakeDomain.Models;
+
+namespace Tests
+{
+    [TestClass]
+    public class UpdateBulkTests 
+    {
+        [TestMethod]
+        public void UpdateBulk_UpdatesAll()
+        {
+            Setup();
+
+            using (var db = Context.Sql())
+            {
+                var posts = db.BlogPosts.ToList();
+
+                Assert.AreEqual(3, db.BlogPosts.Count());
+            }
+
+            using (var db = Context.Sql())
+            {
+                Assert.AreEqual(3, db.BlogPosts.Count());
+            }
+        }
+
+        private static void Setup()
+        {
+            using (var db = Context.Sql())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+
+                var list = new List<BlogPost>(){
+                    BlogPost.Create("T1"),
+                    BlogPost.Create("T2"),
+                    BlogPost.Create("T3")
+                };
+
+                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
+            }
+        }
+
+        [TestMethod]
+        public void InsertAll_WrongColumnOrder_InsertsItems()
+        {
+            using (var db = new ReorderedContext())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+            }
+
+            using (var db = Context.Sql())
+            {
+
+                var list = new List<BlogPost>(){
+                    BlogPost.Create("T1"),
+                    BlogPost.Create("T2"),
+                    BlogPost.Create("T3")
+                };
+
+                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
+            }
+
+            using (var db = Context.Sql())
+            {
+                Assert.AreEqual(3, db.BlogPosts.Count());
+            }
+        }
+
+        [TestMethod]
+        public void InsertAll_WrongColumnOrderAndRenamedColumn_InsertsItems()
+        {
+            using (var db = new RenamedAndReorderedContext())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+                db.Database.ExecuteSqlCommand("drop table dbo.RenamedAndReorderedBlogPosts;");
+                db.Database.ExecuteSqlCommand(RenamedAndReorderedBlogPost.CreateTableSql());
+            }
+
+            using (var db = new RenamedAndReorderedContext())
+            {
+
+                var list = new List<RenamedAndReorderedBlogPost>(){
+                    RenamedAndReorderedBlogPost.Create("T1"),
+                    RenamedAndReorderedBlogPost.Create("T2"),
+                    RenamedAndReorderedBlogPost.Create("T3")
+                };
+
+                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
+            }
+
+            using (var db = new RenamedAndReorderedContext())
+            {
+                Assert.AreEqual(3, db.BlogPosts.Count());
+            }
+        }
+
+        [TestMethod]
+        public void InsertAll_NoProvider_UsesDefaultInsert()
+        {
+            string fallbackText = null;
+
+            Configuration.Log = str => fallbackText = str;
+
+            using (var db = Context.SqlCe())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+            }
+
+            var list = new List<BlogPost>(){
+                    BlogPost.Create("T1"),
+                    BlogPost.Create("T2"),
+                    BlogPost.Create("T3")
+                };
+
+            using (var db = Context.SqlCe())
+            {
+                EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
+            }
+
+            using (var db = Context.SqlCe())
+            {
+                Assert.AreEqual(3, db.BlogPosts.Count());
+            }
+
+            Assert.IsNotNull(fallbackText);
+        }
+
+
+        [TestMethod]
+        public void InsertAll_WithForeignKey()
+        {
+            int postId = -1;
+            using (var db = Context.Sql())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+
+                var bp = BlogPost.Create("B1");
+                db.BlogPosts.Add(bp);
+                db.SaveChanges();
+                postId = bp.ID;
+
+                var comments = new List<Comment>(){
+                    new Comment{Text = "C1", PostId = bp.ID },
+                    new Comment{Text = "C2", PostId = bp.ID },
+                };
+
+                EFBatchOperation.For(db, db.Comments).InsertAll(comments);
+            }
+
+            using (var db = Context.Sql())
+            {
+                Assert.AreEqual(2, db.Comments.Count());
+                Assert.AreEqual(2, db.Comments.Count(c => c.PostId == postId));
+            }
+        }
+    }
+}

--- a/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
@@ -205,7 +205,7 @@ namespace Tests
       public void UpdateAll_NoProvider_UsesDefaultDelete()
       {
           string fallbackText = null;
-
+          Configuration.DisableDefaultFallback = false;
           Configuration.Log = str => fallbackText = str;
 
           using (var db = Context.SqlCe())

--- a/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
@@ -10,7 +10,7 @@ using Tests.FakeDomain.Models;
 namespace Tests
 {
     [TestClass]
-    public class UpdateAllTest
+    public class UpdateByQueryTest
     {
 
       [TestMethod]

--- a/EntityFramework.Utilities/Tests/connectionStrings.json
+++ b/EntityFramework.Utilities/Tests/connectionStrings.json
@@ -1,0 +1,4 @@
+﻿{
+	"SqlServer" : "Data Source=./; Initial Catalog=BatchTests; Integrated Security=SSPI; MultipleActiveResultSets=True",
+	"SqlCe" : "Data Source=BatchTests.sdf"
+}

--- a/EntityFramework.Utilities/Tests/packages.config
+++ b/EntityFramework.Utilities/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.2" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
   <package id="EntityFramework.SqlServerCompact" version="6.0.2" targetFramework="net40" />
   <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.8.3" />


### PR DESCRIPTION
BUG FIX: Issue #27 #37 #31  Now supports Model first
BUG FIX: Issue #29 Now (hopefully) supports Visual Basic
BUG FIX: Issue #22 Now ForceDelete properly escaped table name

FEATURE: TPH support for bulk insert. Only TPH is supported as inheritance strategy. And only tested with strings as discriminator column. It only works if the whole list of items to insert is of the same type. If they are not you need to split them and call InsertAll once for each type. 

FEATURE: Bulk updates. Similar to the InsertAll. The difference from UpdateByQuery is that you take the values from an in value collection which means each item can have a random update. Useful when doing imports etc etc. 

Syntax:

```
var commentsFromDb = db.Comments.AsNoTracking().ToList();
var rand = new Random();
foreach (var item in commentsFromDb)
{
    item.Reads = rand.Next(0, 9999999);
}
EFBatchOperation.For(db, db.Comments).UpdateAll(commentsFromDb, x => x.ColumnsToUpdate(c => c.Reads));
```

Some intial numbers

Batch iteration with 25000 entities
Bulk update all with a random read: 153ms

Standard iteration with 25000 entities
Update all with a random read: 5779ms

