### PR TITLE
EF version update; Fix TPHConfiguration mappings to add ValueConditionMapping value

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
@@ -198,7 +198,7 @@ namespace EntityFramework.Utilities
                     {
                         tableMapping.TPHConfiguration.Mappings.Add(
                             getClr(item.Fragments[0]),
-                            GetNonPublicPropertyValue(item.Fragments[0].Conditions[0], "Value").ToString()
+                            ((ValueConditionMapping)item.Fragments[0].Conditions[0]).Value.ToString()
                             );
                     }
                 }
@@ -243,14 +243,6 @@ namespace EntityFramework.Utilities
         private Type GetClrTypeFromTypeMapping(MetadataWorkspace metadata, ObjectItemCollection objectItemCollection, EntityTypeMapping mapping)
         {
             return GetClrType(metadata, objectItemCollection, mapping.EntityType ?? mapping.IsOfEntityTypes.First());
-        }
-
-
-        static object GetNonPublicPropertyValue(object o, string propertyName)
-        {
-            return o.GetType()
-              .GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Instance)
-              .GetValue(o, null);
         }
 
         private static dynamic GetProperty(string property, object instance)

--- a/EntityFramework.Utilities/PerformanceTests/PerformanceTests.csproj
+++ b/EntityFramework.Utilities/PerformanceTests/PerformanceTests.csproj
@@ -34,11 +34,11 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text">
       <HintPath>..\packages\ServiceStack.Text.3.8.3\lib\net35\ServiceStack.Text.dll</HintPath>

--- a/EntityFramework.Utilities/PerformanceTests/packages.config
+++ b/EntityFramework.Utilities/PerformanceTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.8.3" />
 </packages>

--- a/EntityFramework.Utilities/Tests/Tests.csproj
+++ b/EntityFramework.Utilities/Tests/Tests.csproj
@@ -37,11 +37,11 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServerCompact">
       <HintPath>..\packages\EntityFramework.SqlServerCompact.6.0.2\lib\net40\EntityFramework.SqlServerCompact.dll</HintPath>

--- a/EntityFramework.Utilities/Tests/packages.config
+++ b/EntityFramework.Utilities/Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net40" />
   <package id="EntityFramework.SqlServerCompact" version="6.0.2" targetFramework="net40" />
   <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.8.3" />


### PR DESCRIPTION
Hi @MikaelEliasson,
I noticed that the EntityFramework.Utilities project is not working with TPH as of EF version 6.1.3.

The tests seem to pass but they are still at 6.1.1 if you switch them to 6.1.3 they fail.

The reason for that is a change in EF 6.1.3 that seems to change the type of the items in the Conditions collection from [ConditionPropertyMapping](https://msdn.microsoft.com/en-us/library/system.data.entity.core.mapping.conditionpropertymapping(v=vs.113).aspx) to [ValueConditionMapping](https://msdn.microsoft.com/en-us/library/system.data.entity.core.mapping.valueconditionmapping(v=vs.113).aspx).

This breaks the `Value` retrieval, as the property is no longer `private`.

Sinse the property is public we no longer need to use reflection.

I've made the required changes. Let me know what you think.