### PR TITLE
Fix for Bulk Update always using the default schema for the update target table

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -100,15 +100,15 @@ namespace EntityFramework.Utilities
             var setters = string.Join(",", filtered.Where(c => !c.IsPrimaryKey).Select(c => "[" + c.NameInDatabase + "] = TEMP.[" + c.NameInDatabase + "]"));
             var pks = properties.Where(p => p.IsPrimaryKey).Select(x => "ORIG.[" + x.NameInDatabase + "] = TEMP.[" + x.NameInDatabase + "]");
             var filter = string.Join(" and ",  pks);
-            var mergeCommand =  string.Format(@"UPDATE [{0}]
+            var mergeCommand =  string.Format(@"UPDATE [{0}].[{1}]
                 SET
-                    {3}
+                    {4}
                 FROM
-                    [{0}] ORIG
+                    [{0}].[{1}] ORIG
                 INNER JOIN
-                     [{1}] TEMP
+                     [{0}].[{2}] TEMP
                 ON 
-                    {2}", tableName, tempTableName, filter, setters);
+                    {3}", schema, tableName, tempTableName, filter, setters);
 
             using (var createCommand = new SqlCommand(str, con))
             using (var mCommand = new SqlCommand(mergeCommand, con))


### PR DESCRIPTION
Fixed missing schema addressing in SqlQueryProvider.UpdateItems<T> by adding schema to the string.format to build the update statement
