### PR TITLE
Resolved 2 issues with multi threaded code for issue #57

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -83,7 +83,7 @@ namespace EntityFramework.Utilities
 
         public void UpdateItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, UpdateSpecification<T> updateSpecification)
         {
-            var tempTableName = "temp_" + tableName + "_" + DateTime.Now.Ticks;
+            var tempTableName = "temp_" + tableName + "_" + Guid.NewGuid().ToString("N");
             var columnsToUpdate = updateSpecification.Properties.Select(p => p.GetPropertyName()).ToDictionary(x => x);
             var filtered = properties.Where(p => columnsToUpdate.ContainsKey(p.NameOnObject) || p.IsPrimaryKey).ToList();
             var columns = filtered.Select(c => "[" + c.NameInDatabase + "] " + c.DataType);


### PR DESCRIPTION
1. Fixed identified issue in SqlQueryProvider.cs UpdateItems<T> where using DateTime.Now.Ticks could cause duplicate table names if calls to update happened fast enough for the same main table.

Fixed by switching to GUID
1. Fixed race condition in MappingHelper.cs EfMappingFactory where 2 threads could evaluate if (!cache.TryGetValue(type, out mapping)) before either one had added the context type to the internal cache.

Fixed by adding a lock around the code to add the item to the cache dictionary to prevent 2 threads trying to add the same item.
