### PR TITLE
Small update to allow for batch insert/update operations on entities with computed properties

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
@@ -9,6 +9,7 @@ using System.Data.Entity.Infrastructure;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace EntityFramework.Utilities
 {
@@ -116,6 +117,7 @@ namespace EntityFramework.Utilities
 
                 var properties = tableMapping.PropertyMappings
                     .Where(p => currentType.IsSubclassOf(p.ForEntityType) || p.ForEntityType == currentType)
+                    .Where(p => p.IsComputed == false)
                     .Select(p => new ColumnMapping { NameInDatabase = p.ColumnName, NameOnObject = p.PropertyName }).ToList();
                 if (tableMapping.TPHConfiguration != null)
                 {
@@ -157,6 +159,7 @@ namespace EntityFramework.Utilities
 
                 var properties = tableMapping.PropertyMappings
                     .Where(p => currentType.IsSubclassOf(p.ForEntityType) || p.ForEntityType == currentType)
+                    .Where(p => p.IsComputed == false)
                     .Select(p => new ColumnMapping { 
                         NameInDatabase = p.ColumnName, 
                         NameOnObject = p.PropertyName, 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/MappingHelper.cs
@@ -94,6 +94,7 @@ namespace EntityFramework.Utilities
         public bool IsPrimaryKey { get; set; }
 
         public string DataTypeFull { get; set; }
+        public bool IsComputed { get; set; }
     }
 
     /// <summary>
@@ -155,7 +156,7 @@ namespace EntityFramework.Utilities
                 tableMapping.Schema = mappingToLookAt.Fragments[0].StoreEntitySet.Schema;
                 tableMapping.TableName = mappingToLookAt.Fragments[0].StoreEntitySet.Table ?? mappingToLookAt.Fragments[0].StoreEntitySet.Name;
                 typeMapping.TableMappings.Add(tableMapping);
-
+                
                 Action<Type, System.Data.Entity.Core.Mapping.PropertyMapping, string> recurse = null;
                 recurse = (t, item, path) =>
                 {
@@ -176,7 +177,8 @@ namespace EntityFramework.Utilities
                             DataType = scalar.Column.TypeName,
                             DataTypeFull = GetFullTypeName(scalar),
                             PropertyName = path + item.Property.Name,
-                            ForEntityType = t
+                            ForEntityType = t,
+                            IsComputed = scalar.Column.IsStoreGeneratedComputed
                         });
                     }
                 };


### PR DESCRIPTION
- Added IsComputed to PropertyMapping
- Set PropertyMapping.IsComputed for scalar properties based on prop.Column.IsStoreGenerated
- Changed InsertAll and UpdateAll to skip computed columns

Was unable to add proper tests as there does not appear to be a database creation script in the solution and I didn't feel like reverse engineering one
