### PR TITLE
Changed the UpdateAll method, added an extra '#' symbol to the table …

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -83,7 +83,7 @@ namespace EntityFramework.Utilities
 
         public void UpdateItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, UpdateSpecification<T> updateSpecification)
         {
-            var tempTableName = "temp_" + tableName + "_" + DateTime.Now.Ticks;
+            var tempTableName = "#temp_" + tableName + "_" + DateTime.Now.Ticks;
             var columnsToUpdate = updateSpecification.Properties.Select(p => p.GetPropertyName()).ToDictionary(x => x);
             var filtered = properties.Where(p => columnsToUpdate.ContainsKey(p.NameOnObject) || p.IsPrimaryKey).ToList();
             var columns = filtered.Select(c => "[" + c.NameInDatabase + "] " + c.DataType);


### PR DESCRIPTION
…created/dropped when performing the action. This would ensure that SQL server would treat the table as temporary, and no Permissions issues would appear on the UpdateAll action.

The problem we encountered was when the application user had no rights to create/drop table in the main database. We followed the generated queries and realized that SQL Server does not treat a table named like temp_AAAA_635987400336237839  as temporary, but by simply adding a '#' character the permissions issue is gone. The push request is only related to this problem
