### PR TITLE
updated to support DbGeography type

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -49,7 +49,7 @@ namespace EntityFramework.Utilities
 
         public void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize)
         {
-            using (var reader = new EFDataReader<T>(items, properties))
+            using (var reader = new EFDataReader<T>(items))
             {
                 var con = storeConnection as SqlConnection;
                 if (con.State != System.Data.ConnectionState.Open)


### PR DESCRIPTION
I can't take credit for this work from DJ, but this will add support for dbgeography type. Note: Microsoft.SqlServer.Types will have to be added from nuget to add this support and one other file that reads efdata reader as it no longer needs the 2nd parameter.
