### PR TITLE
Stop multiple enumeration of items

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
@@ -102,6 +102,7 @@ namespace EntityFramework.Utilities
             {
                 Configuration.Log("No provider could be found because the Connection didn't implement System.Data.EntityClient.EntityConnection");
                 Fallbacks.DefaultInsertAll(context, items);
+                return;
             }
 
             var connectionToUse = connection ?? con.StoreConnection;

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFDataReader.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFDataReader.cs
@@ -89,7 +89,7 @@ namespace EntityFramework.Utilities
 
         public override int RecordsAffected
         {
-            get { return this.Items.Count(); }
+            get { throw new NotImplementedException(); }
         }
 
 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -58,7 +58,7 @@ namespace EntityFramework.Utilities
                 }
                 using (SqlBulkCopy copy = new SqlBulkCopy(con))
                 {
-                    copy.BatchSize = Math.Min(reader.RecordsAffected, batchSize ?? 15000); //default batch size
+                    copy.BatchSize = batchSize ?? 15000; //default batch size
                     if (!string.IsNullOrWhiteSpace(schema))
                     {
                         copy.DestinationTableName = string.Format("[{0}].[{1}]", schema, tableName);


### PR DESCRIPTION
The code for bulk insertion currently iterates through the items twice: once when counting them to determine batch size, and once when actually inserting them. This is more-or-less harmless for a `List<T>` datasource, but is problematic when you're generating items (as I was) via a `yield return` kind of construct. I don't think that there's any problem with having a batch size larger than the actual batch, so the simplest way to handle it was just to stop the first (counting) iteration.
