### PR TITLE
Added ability to pass options to SqlBulkCopy for bulk insert

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
@@ -21,7 +21,7 @@ namespace EntityFramework.Utilities
         /// <param name="items">The items to insert</param>
         /// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
         /// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>        
-        void InsertAll<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null) where TEntity : class, T; 
+        void InsertAll<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, SqlTransaction transaction = null) where TEntity : class, T; 
         IEFBatchOperationFiltered<TContext, T> Where(Expression<Func<T, bool>> predicate);
 
 
@@ -95,7 +95,7 @@ namespace EntityFramework.Utilities
         /// <param name="items">The items to insert</param>
         /// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
         /// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
-        public void InsertAll<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null) where TEntity : class, T
+        public void InsertAll<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, SqlTransaction transaction = null) where TEntity : class, T
         {
             var con = context.Connection as EntityConnection;
             if (con == null && connection == null)
@@ -126,7 +126,7 @@ namespace EntityFramework.Utilities
                     });
                 }
 
-                provider.InsertItems(items, tableMapping.Schema, tableMapping.TableName, properties, connectionToUse, batchSize);
+                provider.InsertItems(items, tableMapping.Schema, tableMapping.TableName, properties, connectionToUse, batchSize, copyOptions, transaction);
             }
             else
             {

--- a/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 
@@ -15,7 +16,7 @@ namespace EntityFramework.Utilities
 
         string GetDeleteQuery(QueryInformation queryInformation);
         string GetUpdateQuery(QueryInformation predicateQueryInfo, QueryInformation modificationQueryInfo);
-        void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize);
+        void InsertItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, SqlTransaction transaction = null);
         void UpdateItems<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, UpdateSpecification<T> updateSpecification);
 
         bool CanHandle(DbConnection storeConnection);


### PR DESCRIPTION
Hi!

This is my first contribution, so apologies if this is not done right.
I find the library very useful, but I need to pass specific options to SqlBulkCopy when doing bulk insert.
So I created this fork to showcase my changes and ask if you find them useful to merge into the main library.

I tried to do this as a non-breaking change, so my additional parameters are all optional - this should not break existing code.
All tests seem to pass on my local machine.

Please let me know if you find this a worth-while addition, and please update the nuget version so I would be able to use these changes.
Alternatively I'll just use this as a local file library.

Cheers!