### PR TITLE
Added optional DbConnection to .Update

### DIFF
--- a/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
@@ -244,6 +244,25 @@ namespace Tests
             Assert.IsNotNull(fallbackText);
         }
 
+        [TestMethod]
+        public void UpdateAll_Increment_WithExplicitConnection()
+        {
+            SetupBasePosts();
+
+            int count;
+            using (var db = Context.Sql())
+            {
+                count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").Update(b => b.Reads, b => b.Reads + 5, db.Database.Connection);
+                Assert.AreEqual(1, count);
+            }
+
+            using (var db = Context.Sql())
+            {
+                var post = db.BlogPosts.First(p => p.Title == "T2");
+                Assert.AreEqual(5, post.Reads);
+            }
+        }
+
         private static void SetupBasePosts()
         {
             using (var db = Context.Sql())


### PR DESCRIPTION
Added optional parameter to .Update that accepts an explicit DbConnection. Added test. Followed the same patterns as .InsertAll. 

This is similar to PR #127 which addressed issue #126. 