### PR TITLE
Added optional DbConnection to .Update and .Delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ pip-log.txt
 # Mac crap
 .DS_Store
 packages
+.vs/

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
@@ -54,7 +54,7 @@ namespace EntityFramework.Utilities
 
     public interface IEFBatchOperationFiltered<TContext, T>
     {
-        int Delete();
+        int Delete(DbConnection connection = null);
         int Update<TP>(Expression<Func<T, TP>> prop, Expression<Func<T, TP>> modifier);
     }
     public static class EFBatchOperation
@@ -181,16 +181,17 @@ namespace EntityFramework.Utilities
             return this;
         }
 
-        public int Delete()
+        public int Delete(DbConnection connection = null)
         {
             var con = context.Connection as EntityConnection;
-            if (con == null)
+            if (con == null && connection == null)
             {
                 Configuration.Log("No provider could be found because the Connection didn't implement System.Data.EntityClient.EntityConnection");
                 return Fallbacks.DefaultDelete(context, this.predicate);
             }
+            var connectionToUse = connection ?? con.StoreConnection;
 
-            var provider = Configuration.Providers.FirstOrDefault(p => p.CanHandle(con.StoreConnection));
+            var provider = Configuration.Providers.FirstOrDefault(p => p.CanHandle(connectionToUse));
             if (provider != null && provider.CanDelete)
             {
                 var set = context.CreateObjectSet<T>();
@@ -203,7 +204,7 @@ namespace EntityFramework.Utilities
             }
             else
             {
-                Configuration.Log("Found provider: " + (provider == null ? "[]" : provider.GetType().Name ) + " for " + con.StoreConnection.GetType().Name);
+                Configuration.Log("Found provider: " + (provider == null ? "[]" : provider.GetType().Name ) + " for " + connectionToUse.GetType().Name);
                 return Fallbacks.DefaultDelete(context, this.predicate);
             }
         }

--- a/EntityFramework.Utilities/EntityFramework.Utilities/Properties/AssemblyInfo.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("EntityFramework.Utilities")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Fork of https://github.com/MikaelEliasson/EntityFramework.Utilities")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("EntityFramework.Utilities")]

--- a/EntityFramework.Utilities/Tests/DeleteByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/DeleteByQueryTest.cs
@@ -192,5 +192,40 @@ namespace Tests
             Assert.IsNotNull(fallbackText);
         }
 
+
+        [TestMethod]
+        public void DeleteAll_PropertyEquals_WithExplicitConnection_DeletesAllMatchesAndNothingElse()
+        {
+            using (var db = Context.Sql())
+            {
+                if (db.Database.Exists())
+                {
+                    db.Database.Delete();
+                }
+                db.Database.Create();
+
+                db.BlogPosts.Add(BlogPost.Create("T1"));
+                db.BlogPosts.Add(BlogPost.Create("T2"));
+                db.BlogPosts.Add(BlogPost.Create("T2"));
+                db.BlogPosts.Add(BlogPost.Create("T3"));
+
+                db.SaveChanges();
+            }
+
+            int count;
+            using (var db = Context.Sql())
+            {
+                count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").Delete(db.Database.Connection);
+                Assert.AreEqual(2, count);
+            }
+
+            using (var db = Context.Sql())
+            {
+                var posts = db.BlogPosts.ToList();
+                Assert.AreEqual(2, posts.Count);
+                Assert.AreEqual(0, posts.Count(p => p.Title == "T2"));
+            }
+        }
+
     }
 }

--- a/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
@@ -244,6 +244,25 @@ namespace Tests
             Assert.IsNotNull(fallbackText);
         }
 
+        [TestMethod]
+        public void UpdateAll_Increment_WithExplicitConnection()
+        {
+            SetupBasePosts();
+
+            int count;
+            using (var db = Context.Sql())
+            {
+                count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").Update(b => b.Reads, b => b.Reads + 5, db.Database.Connection);
+                Assert.AreEqual(1, count);
+            }
+
+            using (var db = Context.Sql())
+            {
+                var post = db.BlogPosts.First(p => p.Title == "T2");
+                Assert.AreEqual(5, post.Reads);
+            }
+        }
+
         private static void SetupBasePosts()
         {
             using (var db = Context.Sql())


### PR DESCRIPTION
* Added optional parameter to .Update that accepts an explicit DbConnection. Added test. Followed the same patterns as .InsertAll.

* Added optional parameter to .Delete that accepts an explicit DbConnection. Added test. Followed the same patterns as .InsertAll.

Address issue #126 